### PR TITLE
feat/express request with schema types

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,8 @@ name: Continuous Deployment
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*.*.*'
 

--- a/src/routes/account/credit/controller.test.ts
+++ b/src/routes/account/credit/controller.test.ts
@@ -1,5 +1,5 @@
-import type { Request, Response } from 'express';
-import creditAccountController from './controller';
+import type { Response } from 'express';
+import creditAccountController, { type Request } from './controller';
 import { Account } from '@/models/Account';
 import { Transaction, TransactionType } from '@/models/Transaction';
 import { StatusCodes } from 'http-status-codes';
@@ -11,7 +11,7 @@ describe('creditAccountController', () => {
   beforeEach(() => {
     req = {
       params: { accountId: '123' },
-      body: { amount: 500 },
+      body: { amount: 500, date: '2025-04-02' },
     };
     res = {
       status: jest.fn().mockReturnThis(),

--- a/src/routes/account/credit/controller.ts
+++ b/src/routes/account/credit/controller.ts
@@ -1,7 +1,11 @@
-import type { Request, Response } from 'express';
+import type { Request as ExpressRequest, Response } from 'express';
 import { Account } from '@/models/Account';
 import { Transaction, TransactionType } from '@/models/Transaction';
 import { StatusCodes } from 'http-status-codes';
+import type schema from './schema';
+import type { z } from 'zod';
+
+export type Request = ExpressRequest<z.infer<typeof schema.params>, unknown, z.infer<typeof schema.body>>;
 
 export default async (req: Request, res: Response) => {
   const { accountId } = req.params;


### PR DESCRIPTION
This pull request includes changes to the continuous deployment workflow and updates to the account credit controller and its tests. The most important changes are as follows:

Continuous Deployment Workflow:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R5-R6): Added `main` branch to the list of branches that trigger the workflow on push events.

Account Credit Controller:

* [`src/routes/account/credit/controller.ts`](diffhunk://#diff-ab2d46d8494234da908de1735547d3ca38f449efb3def38a48572fc3f1e90f22L1-R8): Refactored the import of `Request` from `express` and introduced a new `Request` type using `zod` schema.

Account Credit Controller Tests:

* [`src/routes/account/credit/controller.test.ts`](diffhunk://#diff-11d618f84e0a0648d9ec8d3b41679b374563aaf58232d0fad03aeef14fb71759L1-R2): Modified the import of `Request` to align with the refactored controller and added a `date` field to the request body in the `beforeEach` setup. [[1]](diffhunk://#diff-11d618f84e0a0648d9ec8d3b41679b374563aaf58232d0fad03aeef14fb71759L1-R2) [[2]](diffhunk://#diff-11d618f84e0a0648d9ec8d3b41679b374563aaf58232d0fad03aeef14fb71759L14-R14)