### PR TITLE
feat: add Docker Compose configuration for MongoDB and API services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  # MongoDB service
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=password123
+    restart: always
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - transaction-ledger-network
+
+  # API service
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: transaction-ledger-api
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+      - PORT=3000
+      - MONGODB_URI=mongodb://admin:password123@mongodb:27017/transaction_ledger?authSource=admin
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    restart: always
+    networks:
+      - transaction-ledger-network
+
+volumes:
+  mongodb_data:
+    driver: local
+
+networks:
+  transaction-ledger-network:
+    driver: bridge


### PR DESCRIPTION
This pull request includes significant changes to the `docker-compose.yml` file to set up a development environment with MongoDB and an API service. The most important changes include adding services for MongoDB and the API, configuring environment variables and ports, and defining volumes and networks.

Services setup:

* Added MongoDB service with configuration for image, container name, ports, volumes, environment variables, restart policy, healthcheck, and network.
* Added API service with configuration for build context, Dockerfile, container name, ports, environment variables, dependencies, restart policy, and network.

Volumes and networks:

* Defined a volume for MongoDB data storage.
* Defined a bridge network for the services to communicate.