### PR TITLE
test: reorder accountId validation tests for clarity

### DIFF
--- a/src/routes/transaction/list/schema.test.ts
+++ b/src/routes/transaction/list/schema.test.ts
@@ -45,14 +45,14 @@ describe('Transaction list schema', () => {
     expect(() => schema.query.parse(invalidQuery)).toThrow(z.ZodError);
   });
 
-  it('should fail with invalid accountId', () => {
-    const invalidQuery = { accountId: '' };
-    expect(() => schema.query.parse(invalidQuery)).toThrow(z.ZodError);
-  });
-
   it('should validate valid accountId', () => {
     const validQuery = { accountId: '67edcab2b45aa63502e054b9' };
     const parsed = schema.query.parse(validQuery);
     expect(parsed).toEqual(expect.objectContaining({ accountId: '67edcab2b45aa63502e054b9' }));
+  });
+
+  it('should fail with invalid accountId', () => {
+    const invalidQuery = { accountId: '' };
+    expect(() => schema.query.parse(invalidQuery)).toThrow(z.ZodError);
   });
 });


### PR DESCRIPTION
This pull request includes a change to the `src/routes/transaction/list/schema.test.ts` file. The change involves reordering the test cases to ensure that the test for an invalid `accountId` follows the test for a valid `accountId`.
