### PR TITLE
Remove healthcheck from MongoDB service and update husky depedency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # MongoDB service
   mongodb:
@@ -13,12 +11,6 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=password123
     restart: always
-    healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
     networks:
       - transaction-ledger-network
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "express": "^5.1.0",
     "http-status-codes": "^2.3.0",
+    "husky": "^9.1.7",
     "mongoose": "^8.13.1",
     "swagger-ui-express": "^5.0.1",
     "zod": "^3.24.2"
@@ -38,7 +39,6 @@
     "@types/supertest": "^6.0.3",
     "@types/swagger-ui-express": "^4.1.8",
     "dotenv": "^16.4.7",
-    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.1.4",
     "supertest": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       http-status-codes:
         specifier: ^2.3.0
         version: 2.3.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       mongoose:
         specifier: ^8.13.1
         version: 8.13.1
@@ -48,9 +51,6 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.11.16)(@types/node@22.13.17)(typescript@5.8.2))


### PR DESCRIPTION
This pull request includes several changes to the `docker-compose.yml`, `package.json`, and `pnpm-lock.yaml` files. The most important changes involve the removal of the health check for the MongoDB service, the addition and removal of the `husky` dependency, and the update of the `docker-compose` version.

Changes to `docker-compose.yml`:

* Removed the version specification for the Docker Compose file.
* Removed the health check configuration for the MongoDB service.

Dependency updates:

* Added `husky` to the `dependencies` section in `package.json`.
* Removed `husky` from the `devDependencies` section in `package.json`.
* Updated `pnpm-lock.yaml` to reflect the addition and removal of `husky`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17-R19) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL51-L53)