### PR TITLE
fix: add healthcheck to MongoDB service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=password123
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')", "--quiet"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: always
     networks:
       - transaction-ledger-network


### PR DESCRIPTION
This pull request includes an important change to the `docker-compose.yml` file to improve the reliability and monitoring of the MongoDB service. The most significant change is the addition of a health check configuration for the MongoDB service.

Improvements to MongoDB service:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R13-R18): Added a health check configuration to ensure MongoDB is running and responsive. This includes a command to ping the database, with specified intervals, timeouts, retries, and start period.